### PR TITLE
PWN-1248 Fix window k_cli migrate script

### DIFF
--- a/k_cli.rb
+++ b/k_cli.rb
@@ -25,7 +25,7 @@ module Helper
     open_database_connection do
       database_uri = build_database_uri(namespace)
       puts '-> Running the rake db:migrate'
-      puts `DATABASE_URL=#{database_uri} rake db:migrate`
+      puts `rake db:migrate DATABASE_URL=#{database_uri}`
     end
   end
 


### PR DESCRIPTION
Changing command from raw string puts to `system` method so it runs on our Workspaces